### PR TITLE
Allow custom layout, preset colors, support night mode, fix using material items in non-material colorpicker

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,14 +5,14 @@ apply plugin: 'kotlin-kapt'
 apply from: "../ktlint.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.github.dhaval2404.colorpicker.sample"
         minSdkVersion 21
         targetSdkVersion 31
-        versionCode 8
-        versionName "2.3"
+        versionCode 9
+        versionName "2.31"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
@@ -41,10 +41,10 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'androidx.appcompat:appcompat:1.4.0'
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.browser:browser:1.4.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,21 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.0'
+    ext.kotlin_version = '1.7.21'
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        //jcenter plugins
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     // Avoid Kotlin docs error
     tasks.withType(Javadoc) {

--- a/colorpicker/build.gradle
+++ b/colorpicker/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 31
-        versionCode 8
-        versionName "2.3"
+        versionCode 9
+        versionName "2.31"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -40,9 +40,9 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.4.0'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'com.google.android.material:material:1.6.0'
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
 
     testImplementation 'junit:junit:4.13.2'
@@ -63,7 +63,7 @@ ext {
     siteUrl = 'https://github.com/Dhaval2404/ColorPicker/'
     gitUrl = 'https://github.com/Dhaval2404/ColorPicker.git'
 
-    libraryVersion = '2.3'
+    libraryVersion = '2.31'
     //If you are uploading new library try : gradlew install
     //If you are updating existing library then execute: gradlew bintrayUpload
     //In both the case don't forgot to put bintray credentials in local.properties file.
@@ -77,6 +77,6 @@ ext {
     allLicenses = ["Apache-2.0"]
 }
 
-// Place it at the end of the file
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
+//// Place it at the end of the file
+//apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
+//apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'

--- a/colorpicker/src/main/kotlin/com/github/dhaval2404/colorpicker/adapter/ColorPickerAdapter.kt
+++ b/colorpicker/src/main/kotlin/com/github/dhaval2404/colorpicker/adapter/ColorPickerAdapter.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.github.dhaval2404.colorpicker.listener.ColorListener
 import com.github.dhaval2404.colorpicker.model.ColorShape
 import com.github.dhaval2404.colorpicker.util.SharedPref
-import kotlinx.android.synthetic.main.adapter_material_color_picker.view.*
+import androidx.cardview.widget.CardView
 
 /**
  * Adapter for Recent Color
@@ -16,8 +16,8 @@ import kotlinx.android.synthetic.main.adapter_material_color_picker.view.*
  * @version 1.0
  * @since 23 Dec 2019
  */
-class RecentColorAdapter(private val colors: List<String>) :
-    RecyclerView.Adapter<RecentColorAdapter.MaterialColorViewHolder>() {
+class ColorPickerAdapter(private val colors: List<String>) :
+    RecyclerView.Adapter<ColorPickerAdapter.ColorViewHolder>() {
 
     private var colorShape = ColorShape.CIRCLE
     private var colorListener: ColorListener? = null
@@ -45,22 +45,22 @@ class RecentColorAdapter(private val colors: List<String>) :
         }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MaterialColorViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ColorViewHolder {
         val rootView = ColorViewBinding.inflateAdapterItemView(parent)
-        return MaterialColorViewHolder(rootView)
+        return ColorViewHolder(rootView)
     }
 
-    override fun onBindViewHolder(holder: MaterialColorViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: ColorViewHolder, position: Int) {
         holder.bind(position)
     }
 
-    inner class MaterialColorViewHolder(private val rootView: View) :
+    inner class ColorViewHolder(private val rootView: View) :
         RecyclerView.ViewHolder(rootView) {
 
-        private val colorView = rootView.colorView
+        private val cardView = rootView as CardView
 
         init {
-            rootView.setOnClickListener {
+            cardView.setOnClickListener {
                 val index = it.tag as Int
                 if (index < colors.size) {
                     val color = getItem(index)
@@ -72,9 +72,9 @@ class RecentColorAdapter(private val colors: List<String>) :
         fun bind(position: Int) {
             val color = getItem(position)
 
-            rootView.tag = position
-            ColorViewBinding.setBackgroundColor(colorView, color)
-            ColorViewBinding.setCardRadius(colorView, colorShape)
+            cardView.tag = position
+            ColorViewBinding.setBackgroundColor(cardView, color)
+            ColorViewBinding.setCardRadius(cardView, colorShape)
         }
     }
 }

--- a/colorpicker/src/main/kotlin/com/github/dhaval2404/colorpicker/adapter/ColorViewBinding.kt
+++ b/colorpicker/src/main/kotlin/com/github/dhaval2404/colorpicker/adapter/ColorViewBinding.kt
@@ -9,7 +9,7 @@ import com.github.dhaval2404.colorpicker.R
 import com.github.dhaval2404.colorpicker.model.ColorShape
 
 /**
- * Common method for {@see RecentColorAdapter and MaterialColorPickerAdapter}
+ * Common method for {@see ColorPickerAdapter and MaterialColorPickerAdapter}
  *
  * @author Dhaval Patel
  * @version 1.0

--- a/colorpicker/src/main/res/drawable/color_rounded_rectangle.xml
+++ b/colorpicker/src/main/res/drawable/color_rounded_rectangle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke android:width="2dp" android:color="#E6E6E6" />
+    <corners android:radius="8dp" />
+</shape>

--- a/colorpicker/src/main/res/layout/adapter_color_picker.xml
+++ b/colorpicker/src/main/res/layout/adapter_color_picker.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/colorView"
+    android:layout_width="@dimen/color_card_size"
+    android:layout_height="@dimen/color_card_size"
+    card_view:cardBackgroundColor="@color/green_300"
+    android:foreground="@drawable/color_rounded_rectangle"
+    card_view:cardCornerRadius="10dp"
+    android:layout_margin="@dimen/color_card_margin"
+    android:elevation="4dp"
+    android:visibility="visible"
+    />

--- a/colorpicker/src/main/res/layout/dialog_color_picker.xml
+++ b/colorpicker/src/main/res/layout/dialog_color_picker.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 
     <com.github.dhaval2404.colorpicker.ColorPickerView
@@ -16,18 +17,18 @@
         android:layout_marginEnd="24dp"
         android:minWidth="210dp" />
 
-    <com.google.android.material.card.MaterialCardView
+    <androidx.cardview.widget.CardView
         android:id="@+id/colorView"
         android:layout_width="@dimen/color_card_size"
         android:layout_height="@dimen/color_card_size"
         android:layout_marginStart="24dp"
         android:layout_marginEnd="24dp"
-        app:cardBackgroundColor="@color/grey_500"
-        app:cardCornerRadius="8dp"
-        app:cardElevation="4dp"
-        app:cardPreventCornerOverlap="true"
-        app:strokeColor="@color/white"
-        app:strokeWidth="2dp" />
+        card_view:cardBackgroundColor="@color/grey_500"
+        card_view:cardCornerRadius="8dp"
+        card_view:cardElevation="4dp"
+        card_view:cardPreventCornerOverlap="true"
+        card_view:strokeColor="@color/white"
+        card_view:strokeWidth="2dp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/recentColorTitleTxt"
@@ -49,7 +50,7 @@
         tools:itemCount="10"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
-        tools:listitem="@layout/adapter_material_color_picker"
+        tools:listitem="@layout/adapter_color_picker"
         android:layout_gravity="center_horizontal"
         app:layoutManager="androidx.recyclerview.widget.GridLayoutManager" />
 

--- a/colorpicker/src/main/res/values-night/styles.xml
+++ b/colorpicker/src/main/res/values-night/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="MaterialTheme" parent="ThemeOverlay.MaterialComponents.Dark"/>
+</resources>

--- a/colorpicker/src/main/res/values/styles.xml
+++ b/colorpicker/src/main/res/values/styles.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="DialogStyle.Button" parent="Widget.AppCompat.Button.Borderless.Colored" />
+    <style name="MaterialTheme" parent="Theme.MaterialComponents.Light"/>
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
## 🚀 Description
Allow option for using a custom layout
Allow option to set pre-set colors instead of having it use recent colors
Support night mode
Fixed using material views and items in the non-material dialog

## 📄 Motivation and Context
App would crash due to not having material imports even when using the non-material dialog.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
